### PR TITLE
Support SIMD >=3.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SIMDMathFunctions"
 uuid = "d22a7203-ad50-4fbc-abc4-d6ac724cca58"
 authors = ["Thomas Dubos <thomas.dubos@lmd.ipsl.fr> and contributors"]
-version = "0.2.0"
+version = "0.1.3"
 
 [deps]
 SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
-SIMD = "~3.4.0"
+SIMD = "3.4"
 SLEEFPirates = "0.6.42"
 VectorizationBase = "0.21.42"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SIMDMathFunctions"
 uuid = "d22a7203-ad50-4fbc-abc4-d6ac724cca58"
 authors = ["Thomas Dubos <thomas.dubos@lmd.ipsl.fr> and contributors"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"

--- a/src/SIMDMathFunctions.jl
+++ b/src/SIMDMathFunctions.jl
@@ -194,7 +194,7 @@ end
 binops = ((Base,:hypot,SP.hypot), (Base,:^,SP.pow), (FM,:pow_fast, SP.pow_fast))
 for (mod, op_slow, op_fast) in binops
     @eval begin
-        @inline $mod.$op_slow(x::Vec{T}, y::Vec{T}) where {T<:Floats} = vmap($mod.$op_slow, x,y)
+        @inline $mod.$op_slow(x::Vec{T, N}, y::Vec{T, N}) where {T<:Floats, N} = vmap($mod.$op_slow, x,y)
         @inline $mod.$op_slow(x::T, y::Vec{T}) where {T<:Floats} = vmap($mod.$op_slow, x,y)
         @inline $mod.$op_slow(x::Vec{T}, y::T) where {T<:Floats} = vmap($mod.$op_slow, x,y)
         @inline vmap(::typeof($mod.$op_slow), x, y) = SIMDVec($op_fast(VBVec(x), VBVec(y)))


### PR DESCRIPTION
Make one method definition more specific to avoid method ambiguity -- tests pass locally (Ubuntu Linux 22.04) on all SIMD.jl versions greater than and equal to 3.4 (including 3.4, 3.5, 3.6, 3.7.1) -- so ease compat entry to 3.4, which will allow any 3.X.Y versions greater than or equal to 3.4.0. 